### PR TITLE
Fix for issue #2, USBmount fails on Stretch

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -3,3 +3,4 @@
 usbmount usr/share/usbmount
 usbmount.conf etc/usbmount
 usbmount.rules lib/udev/rules.d
+systemd-udevd.service etc/systemd/system/

--- a/systemd-udevd.service
+++ b/systemd-udevd.service
@@ -1,0 +1,30 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=udev Kernel Device Manager
+Documentation=man:systemd-udevd.service(8) man:udev(7)
+DefaultDependencies=no
+Wants=systemd-udevd-control.socket systemd-udevd-kernel.socket
+After=systemd-udevd-control.socket systemd-udevd-kernel.socket systemd-sysusers.service
+Before=sysinit.target
+ConditionPathIsReadWrite=/sys
+
+[Service]
+Type=notify
+OOMScoreAdjust=-1000
+Sockets=systemd-udevd-control.socket systemd-udevd-kernel.socket
+Restart=always
+RestartSec=0
+ExecStart=/lib/systemd/systemd-udevd
+KillMode=mixed
+WatchdogSec=3min
+TasksMax=infinity
+MountFlags=shared
+MemoryDenyWriteExecute=yes
+RestrictRealtime=yes
+RestrictAddressFamilies=AF_UNIX AF_NETLINK AF_INET AF_INET6


### PR DESCRIPTION
On Stretch, udev creates its own filesystem namespace, so the mount is not visible in other filesystem namespaces.

This commit overrides the default systemd-udevd.service, changing the flag MountFlags to "shared" (instead of "slave").