### PR TITLE
Create a label symlink to plugged device

### DIFF
--- a/00_remove_symlinks
+++ b/00_remove_symlinks
@@ -16,7 +16,6 @@ set -e
 ls /var/run/usbmount | while read name; do
     if test "`readlink \"/var/run/usbmount/$name\" || :`" = "$UM_MOUNTPOINT"; then
 	rm -f "/var/run/usbmount/$name"
-	break
     fi
 done
 

--- a/10_create_label_symlink
+++ b/10_create_label_symlink
@@ -1,0 +1,28 @@
+#!/bin/sh
+# This script creates the model name symlink in /var/run/usbmount.
+# Copyright (C) 2005 Martin Dickopp
+#
+# This file is free software; the copyright holder gives unlimited
+# permission to copy and/or distribute it, with or without
+# modifications, as long as this notice is preserved.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY, to the extent permitted by law; without
+# even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.
+#
+set -e
+
+# Get label or exit if no label
+LABEL=`e2label $UM_DEVICE` || exit 0
+
+# Replace spaces with underscores, remove special characters in label
+LABEL=`echo "$LABEL" | sed 's/ /_/g; s/[^0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ._-]//g'`
+
+# Exit if label is empty.
+test -n "$LABEL" || exit 0
+
+# If the symlink does not yet exist, create it.
+test -e "/var/run/usbmount/$LABEL" || ln -sf "$UM_MOUNTPOINT" "/var/run/usbmount/$LABEL"
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ in, the first available mountpoint is automatically selected.
 
 If the device plugged provides a model name, a symbolic link at
 `/var/run/usbmount/MODELNAME` pointing to the mountpoint is automatically
-created.  When the device is not present anymore in the system (e.g.,
+created.
+
+If the device plugged has a label (e2label), a symbolic link at
+`/var/run/usbmount/LABEL` pointing to the mountpoint is automatically
+created.
+
+When the device is not present anymore in the system (e.g.,
 after it has been unplugged), usbmount deletes the symbolic links that
 were created.
 

--- a/debian/install
+++ b/debian/install
@@ -1,5 +1,6 @@
 00_create_model_symlink etc/usbmount/mount.d
-00_remove_model_symlink etc/usbmount/umount.d
+10_create_label_symlink etc/usbmount/mount.d
+00_remove_symlinks etc/usbmount/umount.d
 usbmount usr/share/usbmount
 usbmount.conf etc/usbmount
 90-usbmount.rules lib/udev/rules.d


### PR DESCRIPTION
Added a script in mount.d to create another symlink in
/var/run/usbmount based on the label of the plugged filesystem,
as provided by `e2label`.
Remove symlinks script modified to clean *all* existing symlinks
to unplugged filesystem.
Readme updated.
debian install modified (untested).

Signed-off-by: Oren Duer <oren@nvidia.com>